### PR TITLE
feat: add Elastic IP for stable public address

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,14 +100,24 @@ resource "aws_instance" "dailyfact" {
   }
 }
 
+# --- Elastic IP ---
+
+resource "aws_eip" "dailyfact" {
+  instance = aws_instance.dailyfact.id
+
+  tags = {
+    Name = "dailyfact-eip"
+  }
+}
+
 # --- Outputs ---
 
 output "public_ip" {
-  description = "Public IP of the EC2 instance"
-  value       = aws_instance.dailyfact.public_ip
+  description = "Public IP of the EC2 instance (Elastic IP)"
+  value       = aws_eip.dailyfact.public_ip
 }
 
 output "ssh_command" {
   description = "SSH command to connect to the instance"
-  value       = "ssh -i ~/.ssh/dailyfact-key ec2-user@${aws_instance.dailyfact.public_ip}"
+  value       = "ssh -i ~/.ssh/dailyfact-key ec2-user@${aws_eip.dailyfact.public_ip}"
 }


### PR DESCRIPTION
## Summary
- Adds `aws_eip` resource attached to the EC2 instance
- Outputs now reference the Elastic IP instead of the instance's ephemeral IP
- IP **52.44.102.82** is now permanent — no more secret updates after Terraform changes

## Test plan
- [x] `terraform apply` created EIP successfully
- [x] App accessible at http://52.44.102.82
- [x] `EC2_HOST` GitHub Secret updated to new IP
- [ ] After merge: deploy workflow uses stable IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)